### PR TITLE
Gql foreign keys

### DIFF
--- a/workspace/schema/loader.py
+++ b/workspace/schema/loader.py
@@ -158,3 +158,18 @@ class AuthorLoader(DataLoader):
 
 
 author_loader = AuthorLoader()
+
+
+class TaskLoader(DataLoader):
+    """Task loader."""
+
+    def batch_load_fn(self, keys):
+        """Load tasks by pk."""
+        tasks = {}
+        qs = models.Task.objects.filter(pk__in=keys)
+        for task in qs.iterator():
+            tasks[task.pk] = task
+        return Promise.resolve([tasks.get(key) for key in keys])
+
+
+task_loader = TaskLoader()

--- a/workspace/schema/loader.py
+++ b/workspace/schema/loader.py
@@ -160,6 +160,21 @@ class AuthorLoader(DataLoader):
 author_loader = AuthorLoader()
 
 
+class WorkspaceBoardLoader(DataLoader):
+    """Workspace board loader."""
+
+    def batch_load_fn(self, keys):
+        """Load work space boards by pk."""
+        workspace_boards = {}
+        qs = models.WorkspaceBoard.objects.filter(pk__in=keys)
+        for workspace_board in qs.iterator():
+            workspace_boards[workspace_board.pk] = workspace_board
+        return Promise.resolve([workspace_boards.get(key) for key in keys])
+
+
+workspace_board_loader = WorkspaceBoardLoader()
+
+
 class WorkspaceBoardSectionLoader(DataLoader):
     """Workspace board section loader."""
 

--- a/workspace/schema/loader.py
+++ b/workspace/schema/loader.py
@@ -160,6 +160,21 @@ class AuthorLoader(DataLoader):
 author_loader = AuthorLoader()
 
 
+class WorkspaceLoader(DataLoader):
+    """Workspace loader."""
+
+    def batch_load_fn(self, keys):
+        """Load work spaces by pk."""
+        workspaces = {}
+        qs = models.Workspace.objects.filter(pk__in=keys)
+        for workspace in qs.iterator():
+            workspaces[workspace.pk] = workspace
+        return Promise.resolve([workspaces.get(key) for key in keys])
+
+
+workspace_loader = WorkspaceLoader()
+
+
 class WorkspaceBoardLoader(DataLoader):
     """Workspace board loader."""
 

--- a/workspace/schema/loader.py
+++ b/workspace/schema/loader.py
@@ -160,6 +160,25 @@ class AuthorLoader(DataLoader):
 author_loader = AuthorLoader()
 
 
+class WorkspaceBoardSectionLoader(DataLoader):
+    """Workspace board section loader."""
+
+    def batch_load_fn(self, keys):
+        """Load tasks by pk."""
+        workspace_board_sections = {}
+        qs = models.WorkspaceBoardSection.objects.filter(pk__in=keys)
+        for workspace_board_section in qs.iterator():
+            workspace_board_sections[
+                workspace_board_section.pk
+            ] = workspace_board_section
+        return Promise.resolve(
+            [workspace_board_sections.get(key) for key in keys],
+        )
+
+
+workspace_board_section_loader = WorkspaceBoardSectionLoader()
+
+
 class TaskLoader(DataLoader):
     """Task loader."""
 

--- a/workspace/schema/types.py
+++ b/workspace/schema/types.py
@@ -42,12 +42,17 @@ class WorkspaceBoard(graphene_django.DjangoObjectType):
     """WorkspaceBoard."""
 
     sections = graphene.List("workspace.schema.types.WorkspaceBoardSection")
+    workspace = graphene.Field("workspace.schema.types.Workspace")
 
     def resolve_sections(self, info):
         """Resolve workspace board sections."""
         return loader.workspace_board_workspace_board_section_loader.load(
             self.pk,
         )
+
+    def resolve_workspace(self, info):
+        """Resolve workspace."""
+        return loader.workspace_loader.load(self.workspace.pk)
 
     class Meta:
         """Meta."""

--- a/workspace/schema/types.py
+++ b/workspace/schema/types.py
@@ -84,6 +84,9 @@ class Task(graphene_django.DjangoObjectType):
 
     sub_tasks = graphene.List("workspace.schema.types.SubTask")
     chat_messages = graphene.List("workspace.schema.types.ChatMessage")
+    workspace_board_section = graphene.Field(
+        "workspace.schema.types.WorkspaceBoardSection",
+    )
 
     def resolve_sub_tasks(self, info):
         """Resolve sub tasks for this task."""
@@ -92,6 +95,12 @@ class Task(graphene_django.DjangoObjectType):
     def resolve_chat_messages(self, info):
         """Resolve chat messages for this task."""
         return loader.task_chat_message_loader.load(self.pk)
+
+    def resolve_workspace_board_section(self, info):
+        """Resolve workspace board section for this task."""
+        return loader.workspace_board_section_loader.load(
+            self.workspace_board_section.pk,
+        )
 
     class Meta:
         """Meta."""

--- a/workspace/schema/types.py
+++ b/workspace/schema/types.py
@@ -60,10 +60,15 @@ class WorkspaceBoardSection(graphene_django.DjangoObjectType):
     """WorkspaceBoardSection."""
 
     tasks = graphene.List("workspace.schema.types.Task")
+    workspace_board = graphene.Field("workspace.schema.types.WorkspaceBoard")
 
     def resolve_tasks(self, info):
         """Resolve tasks for this workspace board section."""
         return loader.workspace_board_section_task_loader.load(self.pk)
+
+    def resolve_workspace_board(self, info):
+        """Resolve workspace board."""
+        return loader.workspace_board_loader.load(self.workspace_board.pk)
 
     class Meta:
         """Meta."""

--- a/workspace/schema/types.py
+++ b/workspace/schema/types.py
@@ -110,6 +110,10 @@ class Task(graphene_django.DjangoObjectType):
 class SubTask(graphene_django.DjangoObjectType):
     """SubTask."""
 
+    def resolve_task(self, info):
+        """Resolve task with data loader."""
+        return loader.task_loader.load(self.task.pk)
+
     class Meta:
         """Meta."""
 
@@ -120,6 +124,7 @@ class SubTask(graphene_django.DjangoObjectType):
             "description",
             "uuid",
             "order",
+            "task",
         )
         model = models.SubTask
 

--- a/workspace/test/test_schema.py
+++ b/workspace/test/test_schema.py
@@ -71,6 +71,9 @@ query All(
   }
   workspaceBoardSection(uuid: $workspaceBoardSectionUuid) {
     title
+    workspaceBoard {
+      title
+    }
   }
   task(uuid: $taskUuid) {
     title
@@ -128,6 +131,9 @@ query All(
                 },
                 "workspaceBoardSection": {
                     "title": workspace_board_section.title,
+                    "workspaceBoard": {
+                        "title": workspace_board.title,
+                    },
                 },
                 "task": {
                     "title": task.title,

--- a/workspace/test/test_schema.py
+++ b/workspace/test/test_schema.py
@@ -74,6 +74,9 @@ query All(
   }
   task(uuid: $taskUuid) {
     title
+    workspaceBoardSection {
+      title
+    }
   }
   subTask(uuid: $subTaskUuid) {
     title
@@ -128,6 +131,9 @@ query All(
                 },
                 "task": {
                     "title": task.title,
+                    "workspaceBoardSection": {
+                        "title": workspace_board_section.title,
+                    },
                 },
                 "subTask": {
                     "title": sub_task.title,

--- a/workspace/test/test_schema.py
+++ b/workspace/test/test_schema.py
@@ -77,6 +77,9 @@ query All(
   }
   subTask(uuid: $subTaskUuid) {
     title
+    task {
+      title
+    }
   }
   chatMessage(uuid: $chatMessageUuid) {
     text
@@ -128,6 +131,9 @@ query All(
                 },
                 "subTask": {
                     "title": sub_task.title,
+                    "task": {
+                        "title": task.title,
+                    },
                 },
                 "chatMessage": {
                     "text": chat_message.text,

--- a/workspace/test/test_schema.py
+++ b/workspace/test/test_schema.py
@@ -68,6 +68,9 @@ query All(
   }
   workspaceBoard(uuid: $workspaceBoardUuid) {
     title
+    workspace {
+      title
+    }
   }
   workspaceBoardSection(uuid: $workspaceBoardSectionUuid) {
     title
@@ -128,6 +131,9 @@ query All(
                 },
                 "workspaceBoard": {
                     "title": workspace_board.title,
+                    "workspace": {
+                        "title": workspace.title,
+                    },
                 },
                 "workspaceBoardSection": {
                     "title": workspace_board_section.title,


### PR DESCRIPTION
This allows us to go back the type hierarchy for every type (except workspace). Could be useful to use in the frontend.

Fix #87 