### PR TITLE
Do not recycle data loaders between rqs

### DIFF
--- a/projectify/loader.py
+++ b/projectify/loader.py
@@ -1,0 +1,30 @@
+"""Loader module."""
+from workspace.schema import loader as workspace_loader
+
+
+class Loader:
+    """Combine all loaders into one."""
+
+    def __init__(self):
+        """Initialize the loaders."""
+        self.workspace_user_loader = workspace_loader.WorkspaceUserLoader()
+        self.workspace_workspace_board_loader = (
+            workspace_loader.WorkspaceWorkspaceBoardLoader()
+        )
+        self.workspace_board_workspace_board_section_loader = (
+            workspace_loader.WorkspaceBoardWorkspaceBoardSectionLoader()
+        )
+        self.workspace_board_section_task_loader = (
+            workspace_loader.WorkspaceBoardSectionTaskLoader()
+        )
+        self.task_sub_task_loader = workspace_loader.TaskSubTaskLoader()
+        self.task_chat_message_loader = (
+            workspace_loader.TaskChatMessageLoader()
+        )
+        self.user_loader = workspace_loader.UserLoader()
+        self.workspace_loader = workspace_loader.WorkspaceLoader()
+        self.workspace_board_loader = workspace_loader.WorkspaceBoardLoader()
+        self.workspace_board_section_loader = (
+            workspace_loader.WorkspaceBoardSectionLoader()
+        )
+        self.task_loader = workspace_loader.TaskLoader()

--- a/projectify/views.py
+++ b/projectify/views.py
@@ -3,9 +3,18 @@ from graphene_django import (
     views,
 )
 
+from .loader import (
+    Loader,
+)
+
 
 class GraphQLView(views.GraphQLView):
     """Default GraphQLView override."""
+
+    def get_context(self, request):
+        """Enhance context with data loaders."""
+        request.loader = Loader()
+        return request
 
 
 class GraphQLBatchView(GraphQLView):

--- a/workspace/schema/loader.py
+++ b/workspace/schema/loader.py
@@ -61,9 +61,6 @@ class WorkspaceWorkspaceBoardLoader(DataLoader):
         return Promise.resolve([workspace_boards.get(key, []) for key in keys])
 
 
-workspace_workspace_board_loader = WorkspaceWorkspaceBoardLoader()
-
-
 class WorkspaceBoardWorkspaceBoardSectionLoader(DataLoader):
     """Workspace board section loader for workspace boards."""
 
@@ -85,11 +82,6 @@ class WorkspaceBoardWorkspaceBoardSectionLoader(DataLoader):
         )
 
 
-workspace_board_workspace_board_section_loader = (
-    WorkspaceBoardWorkspaceBoardSectionLoader()
-)
-
-
 class WorkspaceBoardSectionTaskLoader(DataLoader):
     """Task loader for workspace board sections."""
 
@@ -106,9 +98,6 @@ class WorkspaceBoardSectionTaskLoader(DataLoader):
         return Promise.resolve([tasks.get(key, []) for key in keys])
 
 
-workspace_board_section_task_loader = WorkspaceBoardSectionTaskLoader()
-
-
 class TaskSubTaskLoader(DataLoader):
     """SubTask loader for tasks."""
 
@@ -121,9 +110,6 @@ class TaskSubTaskLoader(DataLoader):
         for sub_task in qs.iterator():
             sub_tasks[sub_task.task.pk].append(sub_task)
         return Promise.resolve([sub_tasks.get(key, []) for key in keys])
-
-
-task_sub_task_loader = TaskSubTaskLoader()
 
 
 class TaskChatMessageLoader(DataLoader):
@@ -140,9 +126,6 @@ class TaskChatMessageLoader(DataLoader):
         for chat_message in qs.iterator():
             chat_messages[chat_message.task.pk].append(chat_message)
         return Promise.resolve([chat_messages.get(key, []) for key in keys])
-
-
-task_chat_message_loader = TaskChatMessageLoader()
 
 
 class AuthorLoader(DataLoader):
@@ -172,9 +155,6 @@ class WorkspaceLoader(DataLoader):
         return Promise.resolve([workspaces.get(key) for key in keys])
 
 
-workspace_loader = WorkspaceLoader()
-
-
 class WorkspaceBoardLoader(DataLoader):
     """Workspace board loader."""
 
@@ -185,9 +165,6 @@ class WorkspaceBoardLoader(DataLoader):
         for workspace_board in qs.iterator():
             workspace_boards[workspace_board.pk] = workspace_board
         return Promise.resolve([workspace_boards.get(key) for key in keys])
-
-
-workspace_board_loader = WorkspaceBoardLoader()
 
 
 class WorkspaceBoardSectionLoader(DataLoader):
@@ -206,9 +183,6 @@ class WorkspaceBoardSectionLoader(DataLoader):
         )
 
 
-workspace_board_section_loader = WorkspaceBoardSectionLoader()
-
-
 class TaskLoader(DataLoader):
     """Task loader."""
 
@@ -219,6 +193,3 @@ class TaskLoader(DataLoader):
         for task in qs.iterator():
             tasks[task.pk] = task
         return Promise.resolve([tasks.get(key) for key in keys])
-
-
-task_loader = TaskLoader()

--- a/workspace/schema/loader.py
+++ b/workspace/schema/loader.py
@@ -128,19 +128,16 @@ class TaskChatMessageLoader(DataLoader):
         return Promise.resolve([chat_messages.get(key, []) for key in keys])
 
 
-class AuthorLoader(DataLoader):
+class UserLoader(DataLoader):
     """Author loader."""
 
     def batch_load_fn(self, keys):
         """Load authors for author pks."""
-        authors = {}
+        users = {}
         qs = get_user_model().objects.filter(pk__in=keys)
         for user in qs.iterator():
-            authors[user.pk] = user
-        return Promise.resolve([authors.get(key) for key in keys])
-
-
-author_loader = AuthorLoader()
+            users[user.pk] = user
+        return Promise.resolve([users.get(key) for key in keys])
 
 
 class WorkspaceLoader(DataLoader):

--- a/workspace/schema/types.py
+++ b/workspace/schema/types.py
@@ -5,9 +5,6 @@ import graphene_django
 from .. import (
     models,
 )
-from . import (
-    loader,
-)
 
 
 class Workspace(graphene_django.DjangoObjectType):
@@ -18,11 +15,13 @@ class Workspace(graphene_django.DjangoObjectType):
 
     def resolve_users(self, info):
         """Resolve workspace users."""
-        return loader.workspace_user_loader.load(self.pk)
+        return info.context.loader.workspace_user_loader.load(self.pk)
 
     def resolve_boards(self, info):
         """Resolve workspace boards."""
-        return loader.workspace_workspace_board_loader.load(self.pk)
+        return info.context.loader.workspace_workspace_board_loader.load(
+            self.pk
+        )
 
     class Meta:
         """Meta."""
@@ -46,13 +45,14 @@ class WorkspaceBoard(graphene_django.DjangoObjectType):
 
     def resolve_sections(self, info):
         """Resolve workspace board sections."""
+        loader = info.context.loader
         return loader.workspace_board_workspace_board_section_loader.load(
             self.pk,
         )
 
     def resolve_workspace(self, info):
         """Resolve workspace."""
-        return loader.workspace_loader.load(self.workspace.pk)
+        return info.context.loader.workspace_loader.load(self.workspace.pk)
 
     class Meta:
         """Meta."""
@@ -69,11 +69,15 @@ class WorkspaceBoardSection(graphene_django.DjangoObjectType):
 
     def resolve_tasks(self, info):
         """Resolve tasks for this workspace board section."""
-        return loader.workspace_board_section_task_loader.load(self.pk)
+        return info.context.loader.workspace_board_section_task_loader.load(
+            self.pk
+        )
 
     def resolve_workspace_board(self, info):
         """Resolve workspace board."""
-        return loader.workspace_board_loader.load(self.workspace_board.pk)
+        return info.context.loader.workspace_board_loader.load(
+            self.workspace_board.pk
+        )
 
     class Meta:
         """Meta."""
@@ -100,15 +104,15 @@ class Task(graphene_django.DjangoObjectType):
 
     def resolve_sub_tasks(self, info):
         """Resolve sub tasks for this task."""
-        return loader.task_sub_task_loader.load(self.pk)
+        return info.context.loader.task_sub_task_loader.load(self.pk)
 
     def resolve_chat_messages(self, info):
         """Resolve chat messages for this task."""
-        return loader.task_chat_message_loader.load(self.pk)
+        return info.context.loader.task_chat_message_loader.load(self.pk)
 
     def resolve_workspace_board_section(self, info):
         """Resolve workspace board section for this task."""
-        return loader.workspace_board_section_loader.load(
+        return info.context.loader.workspace_board_section_loader.load(
             self.workspace_board_section.pk,
         )
 
@@ -131,7 +135,7 @@ class SubTask(graphene_django.DjangoObjectType):
 
     def resolve_task(self, info):
         """Resolve task with data loader."""
-        return loader.task_loader.load(self.task.pk)
+        return info.context.loader.task_loader.load(self.task.pk)
 
     class Meta:
         """Meta."""

--- a/workspace/schema/types.py
+++ b/workspace/schema/types.py
@@ -157,7 +157,7 @@ class ChatMessage(graphene_django.DjangoObjectType):
 
     def resolve_author(self, info):
         """Resolve author."""
-        return loader.author_loader.load(self.author.pk)
+        return info.context.loader.user_loader.load(self.author.pk)
 
     class Meta:
         """Meta."""

--- a/workspace/test/conftest.py
+++ b/workspace/test/conftest.py
@@ -57,8 +57,9 @@ def sub_task(task):
 
 
 @pytest.fixture
-def chat_message(task):
+def chat_message(task, workspace_user):
     """Return ChatMessage instance."""
     return factory.ChatMessageFactory(
         task=task,
+        author=workspace_user.user,
     )

--- a/workspace/test/test_schema.py
+++ b/workspace/test/test_schema.py
@@ -92,6 +92,9 @@ query All(
   }
   chatMessage(uuid: $chatMessageUuid) {
     text
+    author {
+      email
+    }
   }
 }
 """
@@ -155,6 +158,9 @@ query All(
                 },
                 "chatMessage": {
                     "text": chat_message.text,
+                    "author": {
+                        "email": workspace_user.user.email,
+                    },
                 },
             },
         }


### PR DESCRIPTION
This fixes a problem where stale data would be served by already initialized data loaders leading to the UI showing old data. The issue was resolved by re-initializing the data loaders between each request. Drawback: Having to re-initialize all data loaders regardless of whether they are used or not could have a performance impact.