### PR TITLE
Update gunicorn-error.log

### DIFF
--- a/gunicorn-error.log
+++ b/gunicorn-error.log
@@ -23,5 +23,5 @@ formatter=generic
 args=(sys.stderr, )
 
 [formatter_generic]
-format=%(levelname)-5s [%(module)s] ~ %(message)s
+format=%(levelname)-s [%(module)s] ~ %(message)s
 class=logging.Formatter


### PR DESCRIPTION
Do not assume fixed string length of up to 5 characters