### PR TITLE
Projectify: Turn loader init into middleware

### DIFF
--- a/projectify/graphql_ws_consumer.py
+++ b/projectify/graphql_ws_consumer.py
@@ -7,6 +7,7 @@ import channels.auth
 import channels_graphql_ws
 
 from . import (
+    middleware,
     schema,
 )
 
@@ -15,6 +16,11 @@ class GraphqlWsConsumer(channels_graphql_ws.GraphqlWsConsumer):
     """Channels WebSocket consumer which provides GraphQL API."""
 
     schema = schema.schema
+
+    middleware = [
+        middleware.atomic_transaction_middleware,
+        middleware.loader_middleware,
+    ]
 
     send_keepalive_every = 30
 

--- a/projectify/middleware.py
+++ b/projectify/middleware.py
@@ -3,10 +3,20 @@ from django.db import (
     transaction,
 )
 
+from .loader import (
+    Loader,
+)
+
 
 # Graphene middlewares
-def atomic_transaction_middleware(next, root, info, **args):
+def atomic_transaction_middleware(next, root, info, *args, **kwargs):
     """Wrap graphql query/mutation in transaction."""
     with transaction.atomic():
-        return_value = next(root, info, **args)
+        return_value = next(root, info, *args, **kwargs)
     return return_value
+
+
+def loader_middleware(next, root, info, *args, **kwargs):
+    """Add loaders to info.context."""
+    info.context.loader = Loader()
+    return next(root, info, *args, **kwargs)

--- a/projectify/settings/base.py
+++ b/projectify/settings/base.py
@@ -166,7 +166,10 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 GRAPHENE = {
     "SCHEMA": "projectify.schema.schema",
     "SUBSCRIPTION_PATH": "/graphql-ws",
-    "MIDDLEWARE": ["projectify.middleware.atomic_transaction_middleware"],
+    "MIDDLEWARE": (
+        "projectify.middleware.atomic_transaction_middleware",
+        "projectify.middleware.loader_middleware",
+    ),
 }
 
 AUTH_USER_MODEL = "user.User"

--- a/projectify/views.py
+++ b/projectify/views.py
@@ -3,18 +3,9 @@ from graphene_django import (
     views,
 )
 
-from .loader import (
-    Loader,
-)
-
 
 class GraphQLView(views.GraphQLView):
     """Default GraphQLView override."""
-
-    def get_context(self, request):
-        """Enhance context with data loaders."""
-        request.loader = Loader()
-        return request
 
 
 class GraphQLBatchView(GraphQLView):


### PR DESCRIPTION
This initializes Loader() as part of middleware, not the view. This potentially allows us to populate loaders inside gql subscriptions as well. Unfortunately it is still broken, because now gql subscriptions don't return anything at all anymore. See https://github.com/datadvance/DjangoChannelsGraphqlWs/issues/91