### PR TITLE
Fix missing description after task create

### DIFF
--- a/projectify/conftest.py
+++ b/projectify/conftest.py
@@ -29,6 +29,7 @@ from django.core.files.base import File
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import client
 from django.utils import timezone
+from django.utils.html import format_html
 
 import pytest
 from faker import Faker
@@ -450,8 +451,9 @@ def task(section: Section, team_member: TeamMember, faker: Faker) -> Task:
     return task_create(
         who=team_member.user,
         section=section,
-        title=faker.sentence(),
-        description=faker.paragraph(),
+        title_description=format_html(
+            "<p>{}</p><p>{}</p>", faker.sentence(), faker.paragraph()
+        ),
         assignee=team_member if faker.pybool() else None,
         due_date=faker.date_time(tzinfo=dt_timezone.utc),
     )
@@ -463,7 +465,9 @@ def other_task(task: Task, section: Section, team_member: TeamMember) -> Task:
     # Make sure that this is created AFTER `task`
     del task
     return task_create(
-        who=team_member.user, section=section, title="I am the other task"
+        who=team_member.user,
+        section=section,
+        title_description="I am the other task",
     )
 
 
@@ -475,7 +479,7 @@ def unrelated_task(
     return task_create(
         who=unrelated_team_member.user,
         section=unrelated_section,
-        title="I am an unrelated task",
+        title_description="I am an unrelated task",
     )
 
 

--- a/projectify/management/commands/take_screenshots.py
+++ b/projectify/management/commands/take_screenshots.py
@@ -14,6 +14,7 @@ from django.core.management.base import BaseCommand
 from django.db import transaction
 from django.db.models.fields.files import FileDescriptor
 from django.urls import reverse
+from django.utils.html import format_html
 
 from faker import Faker
 from selenium import webdriver
@@ -140,8 +141,8 @@ class Command(BaseCommand):
         task_create(
             who=self.owner,
             section=self.in_progress_section,
-            title="Beta testing for level 6",
-            description="Conduct beta testing for level 6 functionality",
+            title_description="<p>Beta testing for level 6</p>"
+            "<p>Conduct beta testing for level 6 functionality</p>",
             assignee=fake.random_element(elements=team_members),
         )
 
@@ -159,8 +160,9 @@ class Command(BaseCommand):
             task_create(
                 who=self.owner,
                 section=self.in_progress_section,
-                title=title,
-                description=description,
+                title_description=format_html(
+                    "<p>{}</p><p>{}</p>", title, description
+                ),
                 assignee=fake.random_element(elements=team_members),
             )
 
@@ -168,21 +170,21 @@ class Command(BaseCommand):
         self.essay_task = task_create(
             who=self.owner,
             section=self.coursework_section,
-            title="Write essay for assignment",
-            description="Complete the essay assignment for the course",
+            title_description="<p>Write essay for assignment</p>"
+            "<p>Complete the essay assignment for the course</p>",
             assignee=fake.random_element(elements=team_members),
         )
         task_create(
             who=self.owner,
             section=self.coursework_section,
-            title="Research methodology review",
+            title_description="Research methodology review",
             assignee=fake.random_element(elements=team_members),
         )
 
         task_create(
             who=self.owner,
             section=self.coursework_section,
-            title="Prepare presentation slides",
+            title_description="Prepare presentation slides",
             assignee=fake.random_element(elements=team_members),
         )
 

--- a/projectify/onboarding/views.py
+++ b/projectify/onboarding/views.py
@@ -55,18 +55,16 @@ def create_sample_sections(
     section_about = section_create(
         who=who, title=_("About Projectify"), project=project
     )
-    task_create(
-        who=who,
-        section=section_about,
-        title=_("Learn how to use Projectify"),
-        assignee=team_member,
-    )
-    task_create(
-        who=who,
-        section=section_about,
-        title=_("Invite my team members"),
-        assignee=team_member,
-    )
+    for title in [
+        _("Learn how to use Projectify"),
+        _("Invite my team members"),
+    ]:
+        task_create(
+            who=who,
+            section=section_about,
+            title_description=title,
+            assignee=team_member,
+        )
 
 
 @login_required
@@ -340,7 +338,7 @@ def new_task(
                 task = task_create(
                     who=request.user,
                     section=section,
-                    title=form.cleaned_data["title"],
+                    title_description=form.cleaned_data["title"],
                     assignee=team_member,
                 )
                 return redirect(

--- a/projectify/test/test_rules.py
+++ b/projectify/test/test_rules.py
@@ -144,7 +144,7 @@ class TestTrialRules:
         assert validate_perm("workspace.create_task", user, workspace)
         customer_cancel_subscription(customer=workspace.customer)
         assert validate_perm("workspace.create_task", user, workspace)
-        task_create(section=section, title="task title", who=user)
+        task_create(section=section, title_description="task title", who=user)
         assert not validate_perm(
             "workspace.create_task", user, workspace, raise_exception=False
         )
@@ -152,7 +152,7 @@ class TestTrialRules:
         assert validate_perm(
             "workspace.create_task", user, workspace, raise_exception=False
         )
-        task_create(section=section, title="task title", who=user)
+        task_create(section=section, title_description="task title", who=user)
 
     def test_create_task(
         self, team_member: TeamMember, section: Section
@@ -163,7 +163,7 @@ class TestTrialRules:
         assert validate_perm("workspace.create_task", user, workspace)
         customer_cancel_subscription(customer=workspace.customer)
         assert validate_perm("workspace.create_task", user, workspace)
-        task_create(section=section, title="task title", who=user)
+        task_create(section=section, title_description="task title", who=user)
         assert not validate_perm(
             "workspace.create_task", user, workspace, raise_exception=False
         )

--- a/projectify/workspace/services/task.py
+++ b/projectify/workspace/services/task.py
@@ -13,6 +13,7 @@ from django.utils.timezone import now
 from django.utils.translation import gettext_lazy as _
 
 from projectify.lib.auth import validate_perm
+from projectify.lib.utils import extract_first_paragraph_text
 from projectify.user.models import User
 
 from ..models import Section, Task, TeamMember
@@ -25,8 +26,7 @@ def task_create(
     *,
     who: User,
     section: Section,
-    title: str,
-    description: Optional[str] = None,
+    title_description: str,
     due_date: Optional[datetime] = None,
     assignee: Optional[TeamMember] = None,
 ) -> Task:
@@ -44,10 +44,17 @@ def task_create(
                 ]
             }
         )
+
+    match extract_first_paragraph_text(title_description):
+        case str() as title:
+            pass
+        case None:
+            title = title_description
+
     task = Task.objects.create(
         section=section,
         title=title,
-        description=description,
+        description=title_description,
         due_date=due_date,
         workspace=workspace,
         assignee=assignee,
@@ -61,17 +68,22 @@ def task_update(
     *,
     who: User,
     task: Task,
-    title: str,
-    description: Optional[str] = None,
+    title_description: str,
     due_date: Optional[datetime] = None,
     assignee: Optional[TeamMember] = None,
 ) -> Task:
     """Update task."""
     validate_perm("workspace.update_task", who, task.workspace)
-    task.title = title
-    task.description = description
+    task.description = title_description
     task.due_date = due_date
     task.assignee = assignee
+
+    match extract_first_paragraph_text(title_description):
+        case str() as title:
+            task.title = title
+        case None:
+            task.title = title_description
+
     task.save()
     return task
 

--- a/projectify/workspace/test/services/test_task.py
+++ b/projectify/workspace/test/services/test_task.py
@@ -27,16 +27,22 @@ def test_create_task(
     """Test adding tasks to a project."""
     count = section.task_set.count()
     task = task_create(
-        who=team_member.user, section=section, title="foo", description="bar"
+        who=team_member.user, section=section, title_description="foo"
     )
+    assert task.title == "foo"
+    assert task.description == "foo"
+
     assert section.task_set.count() == count + 1
+
     task2 = task_create(
         who=team_member.user,
         section=section,
-        title="foo",
-        description="bar",
+        title_description="<p>foo</p><p>bar</p>",
         assignee=other_team_member,
     )
+    assert task2.title == "foo"
+    assert task2.description == "<p>foo</p><p>bar</p>"
+
     assert section.task_set.count() == count + 2
     assert list(section.task_set.all()) == [task2, task]
 
@@ -51,7 +57,7 @@ def test_create_task_unrelated_teammember(
         task_create(
             who=team_member.user,
             section=section,
-            title="foo",
+            title_description="foo",
             assignee=unrelated_team_member,
         )
     assert e.match("belongs to a different workspace")
@@ -62,10 +68,8 @@ def test_task_create_nested(team_member: TeamMember, section: Section) -> None:
     task = task_create(
         who=team_member.user,
         section=section,
-        title="hello",
-        description=None,
+        title_description="foo",
         assignee=team_member,
-        due_date=None,
     )
     assert task.assignee == team_member
 
@@ -77,8 +81,7 @@ def test_add_task_due_date(
     task = task_create(
         section=section,
         who=team_member.user,
-        title="foo",
-        description="bar",
+        title_description="foo",
         due_date=now,
     )
     assert task.due_date is not None
@@ -92,8 +95,7 @@ def test_task_update(
     task_update(
         who=team_member.user,
         task=task,
-        title="Hello world",
-        description=None,
+        title_description="Hello world",
         assignee=other_team_member,
     )
     task.refresh_from_db()
@@ -113,11 +115,13 @@ def test_moving_task_to_other_section(
 ) -> None:
     """Test moving a task around to another section."""
     other_task = task_create(
-        who=team_member.user, title="don't care", section=section
+        who=team_member.user, title_description="don't care", section=section
     )
     assert list(section.task_set.all()) == [other_task, task]
     other_section_task = task_create(
-        who=team_member.user, title="don't care", section=other_section
+        who=team_member.user,
+        title_description="don't care",
+        section=other_section,
     )
     assert list(other_section.task_set.all()) == [other_section_task]
     task_move_after(who=team_member.user, task=task, after=other_section)

--- a/projectify/workspace/views/project.py
+++ b/projectify/workspace/views/project.py
@@ -250,8 +250,8 @@ def _project_detail_view_actions(
                 )
             section: Section = form.cleaned_data["section"]
             enrich_section = section
-            title = form.cleaned_data["title"]
-            task_create(who=request.user, section=section, title=title)
+            t = form.cleaned_data["title"]
+            task_create(who=request.user, section=section, title_description=t)
             template = "workspace/project_detail.html#section"
         case "POST", "minimize_section":
             section_minimize_form = SectionMinimizeForm(

--- a/projectify/workspace/views/task.py
+++ b/projectify/workspace/views/task.py
@@ -22,7 +22,6 @@ from projectify.lib.htmx import (
     HttpResponseClientRefresh,
 )
 from projectify.lib.types import AuthenticatedHttpRequest
-from projectify.lib.utils import extract_first_paragraph_text
 from projectify.lib.views import platform_view
 
 from ..const import TASK_EDITOR_MIN_HEIGHT_CLASS
@@ -130,21 +129,6 @@ class TaskForm(forms.Form):
                 "Couldn't find focus_field=%s in self.fields", focus_field
             )
 
-    def clean(self) -> dict[str, Any]:
-        """Extract title from the first paragraph of description."""
-        cleaned_data = super().clean()
-        # need to cleaned_data.get(field), not cleaned_data[field]. See:
-        # > So you also need to remember to allow for the fact that the fields you are wanting to validate might not have survived the initial individual field checks.
-        # Source: <https://docs.djangoproject.com/en/6.0/ref/forms/validation/#cleaning-and-validating-fields-that-depend-on-each-other>
-        description: Optional[str] = cleaned_data.get("description")
-        if description:
-            first_paragraph = extract_first_paragraph_text(description)
-            if first_paragraph:
-                cleaned_data["title"] = first_paragraph
-            else:
-                cleaned_data["title"] = description
-        return cleaned_data
-
 
 @platform_view
 @require_http_methods(["GET", "POST"])
@@ -193,8 +177,7 @@ def task_create_view(
     task = task_create(
         who=request.user,
         section=section,
-        title=form.cleaned_data["title"],
-        description=form.cleaned_data.get("description"),
+        title_description=form.cleaned_data["description"],
         assignee=form.cleaned_data.get("assignee"),
         due_date=form.cleaned_data.get("due_date"),
     )
@@ -265,7 +248,6 @@ def task_update_view(
         "project": task.section.project,
     }
     task_initial = {
-        "title": task.title,
         "assignee": task.assignee,
         "due_date": task.due_date,
         "description": task.description,
@@ -318,8 +300,7 @@ def task_update_view(
     task_update(
         who=request.user,
         task=task,
-        title=cleaned_data["title"],
-        description=cleaned_data["description"],
+        title_description=cleaned_data["description"],
         due_date=cleaned_data["due_date"],
         assignee=cleaned_data["assignee"],
     )


### PR DESCRIPTION
Fix problem where creating tasks from the project view creates tasks with empty descriptions.

The solution is to put the title/description extracting into the task service.