### PR TITLE
Fix admin checkbox actions.js integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ image types are PNG and JPEG.
 - Fix storefront URLs not rendering by adjusting HTML sanitization
   configuration. Projectify's migration from bleach to JustHTML introduced
   a regression in sanitization behavior.
+- Fix broken checkbox in admin caused by improperly overriding checkbox.html
+  widget
 
 ### Internal
 

--- a/projectify/templates/django/forms/widgets/checkbox.html
+++ b/projectify/templates/django/forms/widgets/checkbox.html
@@ -1,11 +1,10 @@
-{# SPDX-FileCopyrightText: 2025 JWP Consulting GK #}
+{# SPDX-FileCopyrightText: 2025-2026 JWP Consulting GK #}
 {# SPDX-License-Identifier: AGPL-3.0-or-later #}
 {% load projectify %}
 <div class="relative m-0.5 size-4 rounded border border-secondary-hover hover:bg-secondary-hover hover:border-foreground">
-    <input class="peer absolute -left-[3px] -top-[3px] size-5 appearance-none rounded-md border border-transparent"
+    <input {% if widget.attrs %}{% include "django/forms/widgets/attrs.html" %}{% else %}class="peer absolute -left-[3px] -top-[3px] size-5 appearance-none rounded-md border border-transparent"{% endif %}
            type="checkbox"
            name="{{ widget.name }}"
-           {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}
-           {% include "django/forms/widgets/attrs.html" %}>
+           {% if widget.value != None %}value="{{ widget.value|stringformat:'s' }}"{% endif %}>
     <span class="hidden absolute pointer-events-none peer-checked:block">{% icon "check" size=4 %}</span>
 </div>


### PR DESCRIPTION
Overriding checkbox.html removed the 'action-select' class. This fixes the checkbox behavior in the Django admin by check whether widget.attrs contains items and
then including the default widgets/attrs.html
template.